### PR TITLE
fix: Changed the table name in delete item to use client tablename

### DIFF
--- a/delete_item.go
+++ b/delete_item.go
@@ -3,7 +3,6 @@ package dynago
 import (
 	"context"
 	"log"
-	"os"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
@@ -16,11 +15,10 @@ import (
  * @return true if the record was deleted, false otherwise
 */
 func (t *Client) DeleteItem(ctx context.Context, pk string, sk string) error {
-	table := os.Getenv("DYNAMODB_TABLE")
 
 	//delete item from dynamodb
 	input := &dynamodb.DeleteItemInput{
-		TableName: &table,
+		TableName: &t.TableName,
 		Key: map[string]types.AttributeValue{
 			"pk": &types.AttributeValueMemberS{Value: pk},
 			"sk": &types.AttributeValueMemberS{Value: sk},


### PR DESCRIPTION
## Description:

### Changes Made:
The deleteItem function is currently relying on the table name fetched from the environment variable. This requires the maintenance of a separate variable named DYNAMODB_TABLE for the function to operate correctly. To align with the consistency of the codebase and ensure uniformity, I have made modifications to the function. The updated implementation now utilizes the table name configured for the DynamoDB client, bringing it in line with the approach adopted by other functions. This adjustment addresses an oversight where the deleteItem function was not following the same convention as other functions in handling the DynamoDB table name.

Key Points:

### Before:

deleteItem function used the table name from the DYNAMODB_TABLE environment variable.
Required a separate variable (DYNAMODB_TABLE) for correct functionality.
### After:

Modified deleteItem to use the table name configured for the DynamoDB client.
Ensures consistency with other functions in the codebase.
Reason for the Change:
To maintain code consistency and streamline the usage of DynamoDB table names across functions. This change eliminates the need for a separate environment variable (DYNAMODB_TABLE) specific to the deleteItem function, aligning it with the established configuration pattern used by other functions.

## Related Issues:
#9 