### PR TITLE
chore(tests): faster and more stable tests by moving db setup to TestMain

### DIFF
--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -46,10 +46,7 @@ type User struct {
 }
 
 func TestQuery(t *testing.T) {
-	endoint, purge := startLocalDatabase(t)
-	defer purge()
-
-	table := prepareTable(t, endoint, "query_test")
+	table := prepareTable(t, dynamoEndpoint, "query_test")
 	testCases := []struct {
 		title       string
 		condition   string
@@ -245,10 +242,7 @@ func genRandomBytes(t *testing.T, size int) (blk []byte) {
 }
 
 func TestQueryPagination(t *testing.T) {
-	endoint, purge := startLocalDatabase(t)
-	defer purge()
-
-	table := prepareTable(t, endoint, "query_pagination_test")
+	table := prepareTable(t, dynamoEndpoint, "query_pagination_test")
 	// write 3MB worth of sample user records to the database for testing
 	// dynamodb paginates query result by pages of 1MB recors by default.
 	const batchSize = 100

--- a/tests/transact_items_test.go
+++ b/tests/transact_items_test.go
@@ -17,10 +17,7 @@ type Terminal struct {
 }
 
 func TestTransactItems(t *testing.T) {
-	endoint, purge := startLocalDatabase(t)
-	defer purge()
-
-	table := prepareTable(t, endoint, "transcact_item_test")
+	table := prepareTable(t, dynamoEndpoint, "transcact_item_test")
 
 	testCases := []struct {
 		title     string


### PR DESCRIPTION
By using [TestMain](https://pkg.go.dev/testing#hdr-Main) to create the test database and cleanup on test exit, reduce test execution time and improve stability.

Previously, spinning up new docker container for each test incurred lots of time costs, and tests would fail 6 out of 10 times.

![image](https://github.com/oolio-group/dynago/assets/4880359/cdf25ce7-330a-433c-9178-2780502ec20b)
