### PR TITLE
fix: interface type mismatch for TransactItems

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,16 @@
+package dynago_test
+
+import (
+	"testing"
+
+	"github.com/oolio-group/dynago"
+)
+
+func TestClient(t *testing.T) {
+	// test if dynago.Client implements dynago.DynamoClient interface
+	var client dynago.DynamoClient = &dynago.Client{}
+	_, ok := client.(*dynago.Client)
+	if !ok {
+		t.Errorf("client does not implement DynamoClient interface")
+	}
+}

--- a/interface.go
+++ b/interface.go
@@ -29,7 +29,7 @@ type WriteAPI interface {
 
 type TransactionAPI interface {
 	TransactPutItems(ctx context.Context, items []*TransactPutItemsInput) error
-	TransactItems(ctx context.Context, input []types.TransactWriteItem) error
+	TransactItems(ctx context.Context, input ...types.TransactWriteItem) error
 }
 
 type ReadAPI interface {


### PR DESCRIPTION
PR #6 caused an interface - implementation type mismatch for TransactItems function.
This PR fixes the type issue(Interface needs to be corrected), and adds a small test to prevent future occurrences of this kind of scenario.