### PR TITLE
chore: nix dev shell and go upgrade

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake . --extra-experimental-features "nix-command flakes" 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 go.work
 
 coverage
+
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1735523292,
+        "narHash": "sha256-opBsbR/nrGxiiF6XzlVluiHYb6yN/hEwv+lBWTy9xoM=",
+        "owner": "oolio-group",
+        "repo": "nixpkgs",
+        "rev": "6d97d419e5a9b36e6293887a89a078cf85f5a61b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oolio-group",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "dynago";
+
+  # Nixpkgs / NixOS version to use.
+  inputs.nixpkgs.url = "github:oolio-group/nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      # System types to support.
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+
+    in
+    {
+      # Add dependencies that are only needed for development
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              go_1_23
+            ];
+            shellHook = "echo entering dev shell";
+          };
+        });
+    };
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/oolio-group/dynago
 
-go 1.21
+go 1.22
+
+toolchain go1.23
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.24.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,8 @@
 module github.com/oolio-group/dynago/tests
 
-go 1.21
+go 1.22
+
+toolchain go1.23
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.24.0


### PR DESCRIPTION
Use Go version 1.22 as the minimum version and 1.23 as toolchain version for running tests and checks.

Additionally nix shell configuration has been added using for developer convenience.