### PR TITLE
ci: upgraded upload-artifact action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run Tests
         run: make test
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: coverage


### PR DESCRIPTION
Fixes CI. Upload artifact action version 3 had been deprecated.

![image](https://github.com/user-attachments/assets/2b4e3ae8-c8b1-4343-aaf6-9bab82b4b221)
